### PR TITLE
Flush UART after writing

### DIFF
--- a/components/dmx512/dmx512.cpp
+++ b/components/dmx512/dmx512.cpp
@@ -25,6 +25,7 @@ void DMX512::loop() {
     this->uart_->write_array(this->device_values_, this->max_chan_ + 1);
     this->update_ = false;
     this->last_update_ = millis();
+    this->uart_->flush();
   }
 }
 


### PR DESCRIPTION
Forces the UART to write the output buffer at the end of the loop.
Fixes timing issue.