### PR TITLE
add `allow_other_uses` option to pin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ dmx512:
   id: dmx
   uart_id: uart_bus
   enable_pin: GPIO33 # optional
-  tx_pin: GPIO5
+  tx_pin:
+    number: GPIO5
+    allow_other_uses: true
   uart_num: 1
   periodic_update: true # optional
   force_full_frames: false #optional

--- a/example_4x_adj_vbar_pak.yaml
+++ b/example_4x_adj_vbar_pak.yaml
@@ -6,13 +6,17 @@
 uart:
   id: uart_bus
   baud_rate: 250000
-  tx_pin: GPIO2 #ESP8266
+  tx_pin: 
+    number: GPIO2 #ESP8266
+    allow_other_uses: true
   stop_bits: 2
 
 dmx512:
   id: dmx
   uart_id: uart_bus
-  tx_pin: GPIO2 #ESP8266
+  tx_pin: 
+    number: GPIO2 #ESP8266
+    allow_other_uses: true
   uart_num: 1
 
 output:

--- a/example_dmx.yaml
+++ b/example_dmx.yaml
@@ -4,14 +4,18 @@ external_components:
 uart:
   id: uart_bus
   baud_rate: 250000
-  tx_pin: GPIO5
+  tx_pin: 
+    number: GPIO5
+    allow_other_uses: true
   stop_bits: 2
 
 dmx512:
   id: dmx
   uart_id: uart_bus
   enable_pin: GPIO33
-  tx_pin: GPIO5
+  tx_pin: 
+    number: GPIO5
+    allow_other_uses: true
   uart_num: 1
 
 output:


### PR DESCRIPTION
Starting with 2023.12 ESPHome officially supports sharing GPIO pins between components.

Without this option set, compilation will throw an error message.

`allow_other_uses` (Optional, boolean): If the pin is also specified elsewhere in the configuration. By default multiple uses of the same pin will be flagged as an error. This option will suppress the error and is intended for rare cases where a pin is shared between multiple components. Defaults to false.

Confirmed working on  2023.12.0b1.