### PR TITLE
Support for ESP32 with only 2 UART

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dmx512:
   * `uart_id`: Set this to the ID of your UART component
   * `enable_pin`: Set this to the pin number the MAX585 enable pins are connected to. Optional
   * `tx_pin`: Set this to the same pin number as the UART component. This is required for the generation of the break signal. Defaults to GPIO5. If ESPHome >= 2023.12.0 is used, the option `allow_other_uses` has to be set to `true` (here and in the UART component).
-  * `uart_num`: Set this to the internal ESP32 UART number. If only logging is configured, this should be set to 1 (default). 
+  * `uart_num`: Set this to the internal ESP32 UART number. If only logging is configured, this should be set to 1 (default). (Note some ESP32 boards don't have 3 UARTs, check the datasheet of your board if using a different one.)
   * `periodic_update`: If set to false, only state changes are transmitted and the bus is silent in between - violates the specification and may cause some dimmers to turn off
   * `force_full_frames`: If set to true, the full 513-byte frame is always sent. Otherwise, only the configured channels are transmitted.
   * `custom_mab_len`: Set a custom mark-after-break length (in uS, default 12)

--- a/components/dmx512/dmx512esp32.h
+++ b/components/dmx512/dmx512esp32.h
@@ -19,8 +19,10 @@ class DMX512ESP32 : public DMX512 {
         this->uart_idx_ = U0TXD_OUT_IDX;
     } else if(num == 1) {
         this->uart_idx_ = U1TXD_OUT_IDX;
+#ifdef U2TXD_OUT_IDX
     } else if(num == 2) {
         this->uart_idx_ = U2TXD_OUT_IDX;
+#endif
     }
   }
 };


### PR DESCRIPTION
This is a change I needed to support building for the S2 variant (specifically https://www.wemos.cc/en/latest/s2/s2_mini.html ). 

I didn't end up actually using this, however I think it's pretty safe and may help others.

PS: I've also done a write up on the config I did use in the end to get working with a laser light show: https://github.com/sillyfrog/esphome-dmx-laser . If the wiki is enabled, I'm happy to apply the same there in case it's of value to others.

Cheers.