### PR TITLE
Add missing cast for ESP32IDF port index

### DIFF
--- a/components/dmx512/dmx512esp32idf.cpp
+++ b/components/dmx512/dmx512esp32idf.cpp
@@ -10,9 +10,9 @@ namespace dmx512 {
 static const char *TAG = "dmx512";
 
 void DMX512ESP32IDF::send_break() {
-  uart_set_line_inverse(this->uart_idx_, UART_SIGNAL_TXD_INV);
+  uart_set_line_inverse((uart_port_t)this->uart_idx_, UART_SIGNAL_TXD_INV);
   delayMicroseconds(this->break_len_);
-  uart_set_line_inverse(this->uart_idx_, UART_SIGNAL_INV_DISABLE);
+  uart_set_line_inverse((uart_port_t)this->uart_idx_, UART_SIGNAL_INV_DISABLE);
   delayMicroseconds(this->mab_len_);
 }
 


### PR DESCRIPTION
Unless we want to rewrite the class so that the type of `uart_idx_` varies across implementation platforms, this seems the most logical fix.  Testing working on ESPHome 2025.6.2